### PR TITLE
Fix npm run commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ I will eventually ship some precompiled binaries, but that takes some setup. In 
 * clone the repo
 * run `npm install`
 * if you're on MacOS, you will need to have XCode installed
-* run `npm build:mac` or `npm build:win` depending on your platform
+* run `npm run build:mac` or `npm run build:win` depending on your platform
 * install the binary located in `./dist`


### PR DESCRIPTION
Resolves:

```
> npm build:mac
Unknown command: "build:mac"
```