### PR TITLE
feat: custom model url and selection

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,16 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../logo.png?asset'
 import { generateQuery, runQuery, testPostgresConnection } from './lib/db'
-import { getConnectionString, getOpenAiKey, setConnectionString, setOpenAiKey } from './lib/state'
+import {
+  getConnectionString,
+  getOpenAiKey,
+  setConnectionString,
+  setOpenAiKey,
+  getOpenAiBaseUrl,
+  setOpenAiBaseUrl,
+  getOpenAiModel,
+  setOpenAiModel
+} from './lib/state'
 
 function createWindow(): void {
   // Create the browser window.
@@ -76,12 +85,37 @@ app.whenReady().then(() => {
     await setOpenAiKey(openAiKey)
   })
 
+  ipcMain.handle('getOpenAiBaseUrl', async () => {
+    return (await getOpenAiBaseUrl()) ?? ''
+  })
+
+  ipcMain.handle('setOpenAiBaseUrl', async (_, openAiBaseUrl) => {
+    await setOpenAiBaseUrl(openAiBaseUrl)
+  })
+
+  ipcMain.handle('getOpenAiModel', async () => {
+    return (await getOpenAiModel()) ?? ''
+  })
+
+  ipcMain.handle('setOpenAiModel', async (_, openAiModel) => {
+    await setOpenAiModel(openAiModel)
+  })
+
   ipcMain.handle('generateQuery', async (_, input, existingQuery) => {
     try {
       console.log('Generating query with input: ', input, 'and existing query: ', existingQuery)
       const connectionString = await getConnectionString()
       const openAiKey = await getOpenAiKey()
-      const query = await generateQuery(input, connectionString, openAiKey, existingQuery)
+      const openAiBaseUrl = await getOpenAiBaseUrl()
+      const openAiModel = await getOpenAiModel()
+      const query = await generateQuery(
+        input,
+        connectionString,
+        openAiKey,
+        existingQuery,
+        openAiBaseUrl,
+        openAiModel
+      )
       return {
         error: null,
         data: query

--- a/src/main/lib/db.ts
+++ b/src/main/lib/db.ts
@@ -1,6 +1,6 @@
 import pg from 'pg'
-import { generateObject } from "ai";
-import { createOpenAI } from '@ai-sdk/openai';
+import { generateObject } from 'ai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { z } from 'zod'
 
 export async function testPostgresConnection(connectionString: string): Promise<boolean> {
@@ -29,17 +29,23 @@ export async function generateQuery(
   input: string,
   connectionString: string,
   openAiKey: string,
-  existingQuery: string
+  existingQuery: string,
+  openAiUrl?: string,
+  openAiModel?: string
 ) {
   try {
     const openai = createOpenAI({
-      apiKey: openAiKey
+      apiKey: openAiKey,
+      baseURL: openAiUrl || undefined
     })
     const tableSchema = await getTableSchema(connectionString)
     const existing = existingQuery.trim()
 
+    // Use provided model or default to gpt-4o
+    const modelToUse = openAiModel || 'gpt-4o'
+
     const result = await generateObject({
-      model: openai('gpt-4o'),
+      model: openai(modelToUse),
       system: `You are a SQL (postgres) and data visualization expert. Your job is to help the user write or modify a SQL query to retrieve the data they need. The table schema is as follows:
       ${tableSchema}
       Only retrieval queries are allowed.

--- a/src/main/lib/state.ts
+++ b/src/main/lib/state.ts
@@ -5,12 +5,16 @@ import { z } from 'zod'
 
 const settingsSchema = z.object({
   connectionString: z.string().nullable(),
-  openAiKey: z.string().nullable()
+  openAiKey: z.string().nullable(),
+  openAiBaseUrl: z.string().nullable(),
+  openAiModel: z.string().nullable()
 })
 
 const defaultSettings = {
   connectionString: null,
-  openAiKey: null
+  openAiKey: null,
+  openAiBaseUrl: null,
+  openAiModel: null
 }
 
 function rootDir() {
@@ -54,6 +58,16 @@ export async function getOpenAiKey() {
   return settings.openAiKey
 }
 
+export async function getOpenAiBaseUrl() {
+  const settings = await getSettings()
+  return settings.openAiBaseUrl
+}
+
+export async function getOpenAiModel() {
+  const settings = await getSettings()
+  return settings.openAiModel
+}
+
 export async function setConnectionString(connectionString: string) {
   const settings = await getSettings()
   settings.connectionString = connectionString
@@ -63,5 +77,17 @@ export async function setConnectionString(connectionString: string) {
 export async function setOpenAiKey(openAiKey: string) {
   const settings = await getSettings()
   settings.openAiKey = openAiKey
+  await setSettings(settings)
+}
+
+export async function setOpenAiBaseUrl(openAiBaseUrl: string) {
+  const settings = await getSettings()
+  settings.openAiBaseUrl = openAiBaseUrl
+  await setSettings(settings)
+}
+
+export async function setOpenAiModel(openAiModel: string) {
+  const settings = await getSettings()
+  settings.openAiModel = openAiModel
   await setSettings(settings)
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -11,6 +11,10 @@ declare global {
       ) => Promise<{ error: string | null; data: string }>
       getOpenAiKey: () => Promise<string>
       setOpenAiKey: (openAiKey: string) => Promise<boolean>
+      getOpenAiBaseUrl: () => Promise<string>
+      setOpenAiBaseUrl: (openAiBaseUrl: string) => Promise<boolean>
+      getOpenAiModel: () => Promise<string>
+      setOpenAiModel: (openAiModel: string) => Promise<boolean>
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,7 +14,13 @@ try {
     generateQuery: async (input: string, sqlQuery: string) =>
       await ipcRenderer.invoke('generateQuery', input, sqlQuery),
     getOpenAiKey: async () => await ipcRenderer.invoke('getOpenAiKey'),
-    setOpenAiKey: async (openAiKey: string) => await ipcRenderer.invoke('setOpenAiKey', openAiKey)
+    setOpenAiKey: async (openAiKey: string) => await ipcRenderer.invoke('setOpenAiKey', openAiKey),
+    getOpenAiBaseUrl: async () => await ipcRenderer.invoke('getOpenAiBaseUrl'),
+    setOpenAiBaseUrl: async (openAiBaseUrl: string) =>
+      await ipcRenderer.invoke('setOpenAiBaseUrl', openAiBaseUrl),
+    getOpenAiModel: async () => await ipcRenderer.invoke('getOpenAiModel'),
+    setOpenAiModel: async (openAiModel: string) =>
+      await ipcRenderer.invoke('setOpenAiModel', openAiModel)
   })
 } catch (error) {
   console.error(error)

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -3,7 +3,8 @@ import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
-import { TestTube } from 'lucide-react'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
+import { TestTube, ChevronDown } from 'lucide-react'
 import { useToast } from '../hooks/use-toast'
 import { ModeToggle } from './ui/mode-toggle'
 
@@ -16,6 +17,15 @@ export const Settings = () => {
   const [apiKeyError, setApiKeyError] = useState<string | null>(null)
   const [apiKeySuccess, setApiKeySuccess] = useState<string | null>(null)
   const [isSavingApiKey, setIsSavingApiKey] = useState(false)
+  const [openAIBaseUrl, setOpenAIBaseUrl] = useState<string>('')
+  const [baseUrlError, setBaseUrlError] = useState<string | null>(null)
+  const [baseUrlSuccess, setBaseUrlSuccess] = useState<string | null>(null)
+  const [isSavingBaseUrl, setIsSavingBaseUrl] = useState(false)
+  const [openAIModel, setOpenAIModel] = useState<string>('')
+  const [modelError, setModelError] = useState<string | null>(null)
+  const [modelSuccess, setModelSuccess] = useState<string | null>(null)
+  const [isSavingModel, setIsSavingModel] = useState(false)
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false)
 
   const { toast } = useToast()
 
@@ -54,6 +64,36 @@ export const Settings = () => {
     loadSavedApiKey()
   }, [toast])
 
+  // Load the saved OpenAI base URL when the component mounts
+  useEffect(() => {
+    const loadSavedBaseUrl = async () => {
+      try {
+        const savedBaseUrl = await window.context.getOpenAiBaseUrl()
+        if (savedBaseUrl) {
+          setOpenAIBaseUrl(savedBaseUrl)
+        }
+      } catch (error: any) {
+        setBaseUrlError('Failed to load the OpenAI base URL. Please try again.')
+      }
+    }
+    loadSavedBaseUrl()
+  }, [toast])
+
+  // Load the saved OpenAI model when the component mounts
+  useEffect(() => {
+    const loadSavedModel = async () => {
+      try {
+        const savedModel = await window.context.getOpenAiModel()
+        if (savedModel) {
+          setOpenAIModel(savedModel)
+        }
+      } catch (error: any) {
+        setModelError('Failed to load the OpenAI model. Please try again.')
+      }
+    }
+    loadSavedModel()
+  }, [toast])
+
   const updateConnectionString = async () => {
     setIsTesting(true)
     setSuccessMessage(null)
@@ -87,6 +127,36 @@ export const Settings = () => {
       setApiKeyError('Failed to save the OpenAI API key: ' + error.message)
     } finally {
       setIsSavingApiKey(false)
+    }
+  }
+
+  const updateOpenAIBaseUrl = async () => {
+    setIsSavingBaseUrl(true)
+    setBaseUrlSuccess(null)
+    setBaseUrlError(null)
+    try {
+      await window.context.setOpenAiBaseUrl(openAIBaseUrl)
+      setBaseUrlError(null)
+      setBaseUrlSuccess('Base URL saved successfully.')
+    } catch (error: any) {
+      setBaseUrlError('Failed to save the OpenAI base URL: ' + error.message)
+    } finally {
+      setIsSavingBaseUrl(false)
+    }
+  }
+
+  const updateOpenAIModel = async () => {
+    setIsSavingModel(true)
+    setModelSuccess(null)
+    setModelError(null)
+    try {
+      await window.context.setOpenAiModel(openAIModel)
+      setModelError(null)
+      setModelSuccess('Model ID saved successfully.')
+    } catch (error: any) {
+      setModelError('Failed to save the OpenAI model: ' + error.message)
+    } finally {
+      setIsSavingModel(false)
     }
   }
 
@@ -191,6 +261,80 @@ export const Settings = () => {
           >
             <span>{isSavingApiKey ? 'Saving...' : 'Save Key'}</span>
           </Button>
+
+          <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" className="flex items-center space-x-1.5 h-8 px-3 text-xs">
+                <ChevronDown
+                  className={`w-3.5 h-3.5 transition-transform ${isAdvancedOpen ? 'rotate-180' : ''}`}
+                />
+                <span>Advanced Options</span>
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-3 pt-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="openai-base-url" className="text-xs">
+                  Base URL (Optional)
+                </Label>
+                <Input
+                  id="openai-base-url"
+                  type="text"
+                  value={openAIBaseUrl}
+                  onChange={(e) => setOpenAIBaseUrl(e.target.value)}
+                  placeholder="https://api.openai.com/v1"
+                  className="font-mono text-xs h-8"
+                  autoComplete="off"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Custom base URL for OpenAI API. Leave empty to use the default OpenAI endpoint.
+                  Useful for OpenAI-compatible APIs like Azure OpenAI or local models.
+                </p>
+                {baseUrlError && <p className="text-xs text-destructive">{baseUrlError}</p>}
+                {baseUrlSuccess && <p className="text-xs text-green-500">{baseUrlSuccess}</p>}
+              </div>
+
+              <Button
+                onClick={updateOpenAIBaseUrl}
+                disabled={isSavingBaseUrl}
+                className="flex items-center space-x-1.5 h-8 px-3 text-xs"
+                size="sm"
+                variant="outline"
+              >
+                <span>{isSavingBaseUrl ? 'Saving...' : 'Save Base URL'}</span>
+              </Button>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="openai-model" className="text-xs">
+                  Model (Optional)
+                </Label>
+                <Input
+                  id="openai-model"
+                  type="text"
+                  value={openAIModel}
+                  onChange={(e) => setOpenAIModel(e.target.value)}
+                  placeholder="gpt-4o"
+                  className="font-mono text-xs h-8"
+                  autoComplete="off"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Model ID to use for query generation. Leave empty to use gpt-4o (default).
+                  Examples: gpt-4, gpt-3.5-turbo, claude-3-sonnet, or custom model names.
+                </p>
+                {modelError && <p className="text-xs text-destructive">{modelError}</p>}
+                {modelSuccess && <p className="text-xs text-green-500">{modelSuccess}</p>}
+              </div>
+
+              <Button
+                onClick={updateOpenAIModel}
+                disabled={isSavingModel}
+                className="flex items-center space-x-1.5 h-8 px-3 text-xs"
+                size="sm"
+                variant="outline"
+              >
+                <span>{isSavingModel ? 'Saving...' : 'Save Model'}</span>
+              </Button>
+            </CollapsibleContent>
+          </Collapsible>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
Adds an `Advanced` section to the model settings which allows you to set an OpenAI-compatible custom base URL and model ID to use. Useful for pointing to local models.

Tested with `ollama` and `qwb3:1.7b`

Default view:
![Screenshot 2025-06-20 at 18 11 35](https://github.com/user-attachments/assets/530caa58-4bb2-4e0e-8cf7-8b62febae118)
![Screenshot 2025-06-20 at 18 10 34](https://github.com/user-attachments/assets/c29c177a-bc62-40fa-abcc-fe49f7ee1aec)

Success state:
![Screenshot 2025-06-20 at 18 11 23](https://github.com/user-attachments/assets/b4132ad6-f837-4177-8edf-0e046390a34a)
