### PR TITLE
Add macOS code signing and notarization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,36 @@ https://github.com/user-attachments/assets/15da0076-7bc4-4a20-a65b-103838ce3bc5
 
 💬 [Join the Telegram group to chat with the devs + share feedback!](https://t.me/+QJu4_a2yImo3OTY0)
 
-### Build SnapQL locally
+---
+
+### 🧑‍💻 Build SnapQL locally
+
 I will eventually ship some precompiled binaries, but that takes some setup. In the meantime, follow these steps to build a local copy:
 
-* clone the repo
-* run `npm install`
-* if you're on MacOS, you will need to have XCode installed
-* run `npm run build:mac` or `npm run build:win` depending on your platform
-* install the binary located in `./dist`
+* Clone the repo
+* Run `npm install`
+* If you're on MacOS, you will need to have XCode installed
+* Run one of the following:
+  * `npm run build:mac` — for a plain build
+  * `npm run build:win` — for Windows
+  * `npm run dist:mac` — for a **signed and notarized macOS build** (see setup below)
+* Install the binary located in `./dist`
+
+---
+
+### 🧑‍💻 MacOS Signing & Notarization
+
+If you want to build a signed & notarized macOS app (`npm run dist:mac`), you need to:
+
+1. Have an **Apple Developer account**.
+2. Create an **App-specific password** for notarization.
+3. Set the following environment variables before running the build:
+   ```bash
+   export APPLE_ID="your-apple-id@example.com"
+   export APPLE_ID_PASSWORD="your-app-specific-password"
+   export ASC_PROVIDER="your-apple-team-id"
+   export CSC_NAME="Developer ID Application: Your Name (TeamID)"
+
+4. Run:
+   ```bash
+   npm run dist:mac

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -2,11 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
+    <!-- Entitlements existing -->
+    <key>com.apple.security.cs.allow-jit</key><true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+
+    <!-- Required entitlements for sandbox and network -->
+    <key>com.apple.security.app-sandbox</key><true/>
+    <key>com.apple.security.inherit</key><true/>
+    <key>com.apple.security.network.client</key><true/>
   </dict>
 </plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
 asarUnpack:
   - resources/**
+
 win:
   target:
     - target: nsis
@@ -18,22 +19,29 @@ win:
         - x64
   icon: logo.png
   executableName: snap-ql
+
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
+
 mac:
   icon: logo.png
+  hardenedRuntime: true
+  entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
+  gatekeeperAssess: false
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
+
 dmg:
   artifactName: ${name}-${version}.${ext}
+
 linux:
   icon: logo.png
   target:
@@ -42,9 +50,12 @@ linux:
     - deb
   maintainer: electronjs.org
   category: Utility
+
 appImage:
   artifactName: ${name}-${version}.${ext}
+
 npmRebuild: false
+
 publish:
   provider: generic
   url: https://example.com/auto-updates

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
-    "build:linux": "electron-vite build && electron-builder --linux"
+    "build:linux": "electron-vite build && electron-builder --linux",
+    "dist:mac": "electron-builder --mac --publish never"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",


### PR DESCRIPTION
This PR adds support for code-signing and notarization on macOS.

✅ Updated `electron-builder.yml` to enable hardenedRuntime, entitlements, and notarization.
✅ Added `build/entitlements.mac.plist` with required entitlements.
✅ Added npm script `dist:mac` to easily build and notarize on macOS.
✅ Updated README with setup instructions for developer credentials.

Requires the following environment variables on the build machine:
- APPLE_ID
- APPLE_ID_PASSWORD
- ASC_PROVIDER
- CSC_NAME
