### PR TITLE
Create a Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.check_tag.outputs.release_created }}
+      release_version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get package version
+        id: get_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists and create release
+        id: check_tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.get_version.outputs.version }}"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping release creation"
+            echo "release_created=false" >> $GITHUB_OUTPUT
+          else
+            echo "Creating release for version $VERSION"
+            gh release create "$VERSION" \
+              --title "Release $VERSION" \
+              --notes "Release $VERSION" \
+              --draft=false \
+              --prerelease=false
+            echo "release_created=true" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: create-release
+    if: needs.create-release.outputs.release_created == 'true'
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+          - os: macos-latest
+            platform: macos
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for Linux
+        if: matrix.platform == 'linux'
+        run: npm run build:linux
+
+      - name: Build for Windows
+        if: matrix.platform == 'windows'
+        run: npm run build:win
+
+      - name: Build for macOS
+        if: matrix.platform == 'macos'
+        run: npm run build:mac
+
+      - name: Upload Linux artifacts
+        if: matrix.platform == 'linux'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ needs.create-release.outputs.release_version }}"
+          
+          # List all files in dist to debug
+          echo "Files in dist:"
+          ls -la ./dist/
+          
+          # Upload all Linux artifacts
+          for file in ./dist/*.AppImage ./dist/*.deb ./dist/*.snap; do
+            if [ -f "$file" ]; then
+              echo "Uploading $file"
+              gh release upload "$VERSION" "$file" --clobber
+            fi
+          done
+
+      - name: Upload Windows artifacts
+        if: matrix.platform == 'windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $VERSION = "v${{ needs.create-release.outputs.release_version }}"
+          
+          # List all files in dist to debug
+          Write-Host "Files in dist:"
+          Get-ChildItem ./dist/
+          
+          # Upload all Windows artifacts
+          Get-ChildItem ./dist/ -Filter "*.exe" | ForEach-Object {
+            Write-Host "Uploading $($_.Name)"
+            gh release upload "$VERSION" $_.FullName --clobber
+          }
+
+      - name: Upload macOS artifacts
+        if: matrix.platform == 'macos'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ needs.create-release.outputs.release_version }}"
+          
+          # List all files in dist to debug
+          echo "Files in dist:"
+          ls -la ./dist/
+          
+          # Upload all macOS artifacts
+          for file in ./dist/*.dmg ./dist/*.zip; do
+            if [ -f "$file" ]; then
+              echo "Uploading $file"
+              gh release upload "$VERSION" "$file" --clobber
+            fi
+          done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow includes steps for creating a release, building the project for multiple platforms, and uploading platform-specific build artifacts to the release.

### New GitHub Actions Workflow for Releases:

* **Workflow Name and Triggers**: Added a new workflow named `Release` that triggers on pushes to the `main` or `master` branches, as well as manual dispatch (`.github/workflows/release.yml`).

* **Release Creation Job**: Introduced a `create-release` job that checks if a release tag already exists, creates a new release if not, and outputs metadata such as `release_created` and `release_version` (`.github/workflows/release.yml`).

* **Build Job with Platform Matrix**: Added a `build` job that runs on a platform matrix (Linux, Windows, macOS) to build the project using platform-specific commands and Node.js version 18 (`.github/workflows/release.yml`).

* **Artifact Uploading**: Implemented steps to upload build artifacts (e.g., `.AppImage`, `.deb`, `.exe`, `.dmg`, `.zip`) for each platform to the release, with debugging steps to list files in the `dist` directory (`.github/workflows/release.yml`). (F0ae3038